### PR TITLE
パンくずリスト追加

### DIFF
--- a/app/views/matters/category_search.html.haml
+++ b/app/views/matters/category_search.html.haml
@@ -1,4 +1,7 @@
 検索結果
+.breadcrumb
+  - breadcrumb :category_search_matters
+  = breadcrumbs separator: " &rsaquo; "
 %br
 = @matter_category_searchs.count
 件がヒットしました。
@@ -42,5 +45,3 @@
         = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
 
     %br
-
-= link_to "TOPページへ戻る", root_path

--- a/app/views/matters/search.html.haml
+++ b/app/views/matters/search.html.haml
@@ -1,4 +1,7 @@
 検索結果
+.breadcrumb
+  - breadcrumb :search_matters
+  = breadcrumbs separator: " &rsaquo; "
 %br
 = @matter_searchs.count
 件がヒットしました。
@@ -42,5 +45,3 @@
         = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
 
     %br
-
-= link_to "TOPページへ戻る", root_path

--- a/app/views/offered_lists/index.html.haml
+++ b/app/views/offered_lists/index.html.haml
@@ -1,4 +1,7 @@
 オファー案件一覧ページ
+.breadcrumb
+  - breadcrumb :offered_list
+  = breadcrumbs separator: " &rsaquo; "
 %br
 %br
 
@@ -29,13 +32,6 @@
             = link_to "未確認に戻す", "/users/#{offer.user.id}/offered_lists/#{offer.id}/unconfirm", method: :put
 
         %br
-        %br
-
-
 
 - if @offers.blank?
   ※オファーが送られた案件はありません。
-
-
-%br
-= link_to "TOPページへ戻る", root_path

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -1,4 +1,7 @@
 オファーページ
+.breadcrumb
+  - breadcrumb :offer
+  = breadcrumbs separator: " &rsaquo; "
 
 .user__content
   .user__content__name
@@ -62,8 +65,3 @@
     %br
 - else
   ※オファーを出した案件はありません。
-
-
-%br
-%br
-= link_to "TOPページへ戻る", root_path

--- a/app/views/tags/user_search.html.haml
+++ b/app/views/tags/user_search.html.haml
@@ -1,4 +1,7 @@
 ユーザースキル検索結果
+.breadcrumb
+  - breadcrumb :user_search_tags
+  = breadcrumbs separator: " &rsaquo; "
 %br
 = @user_skill_searchs.count
 件のユーザーがヒットしました。
@@ -54,5 +57,3 @@
         - else
           ※案件依頼を作成すると、ユーザーにオファーを出せます。
     %br
-
-= link_to "TOPページへ戻る", root_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -96,6 +96,35 @@ crumb :musician_chatpage do
   parent :musician_chatslists
 end
 
+# 案件検索結果ページ(キーワード検索)
+crumb :search_matters do
+  link "検索結果", search_matters_path
+  parent :root
+end
+
+# 案件検索結果ページ(カテゴリ検索)
+crumb :category_search_matters do
+  link "検索結果", category_search_matters_path
+  parent :root
+end
+
+# ユーザースキル検索結果ページ
+crumb :user_search_tags do
+  link "ユーザー検索", user_search_musician_tags_path(current_user.musician.id)
+  parent :musician
+end
+
+# 案件オファーページ
+crumb :offer do
+  link "オファーページ", user_offers_path
+  parent :user_search_tags
+end
+
+# オファーが届いた案件の一覧ページ
+crumb :offered_list do
+  link "オファー一覧ページ", user_offered_lists_path
+  parent :mypage
+end
 
 # crumb :projects do
 #   link "Projects", projects_path


### PR DESCRIPTION
パンくずを追加したページは以下の通り。

###### ユーザー機能ページ
・案件検索結果ページ(キーワード検索、カテゴリ検索)
・オファー案件の一覧ページ
###### アーティスト機能ページ
・ユーザースキル検索結果ページ
・オファー作成ページ