### PR TITLE
案件の公開設定反映

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,7 +1,7 @@
 class LikesController < ApplicationController
 
   def index
-     @likes = Like.where(user_id: current_user.id)
+     @likes = Like.where(user_id: current_user.id).order("created_at DESC")
   end
 
   def create

--- a/app/controllers/matters_controller.rb
+++ b/app/controllers/matters_controller.rb
@@ -1,11 +1,13 @@
 class MattersController < ApplicationController
   before_action :set_matter, only: [:edit, :show]
-  before_action :set_deadline, only: [:index, :show]
+  before_action :set_deadline, only: [:index, :show, :search, :category_search]
 
-  PER = 3
+  PER = 5
 
   def index
     @matters = Matter.page(params[:page]).per(PER).order("created_at DESC")
+    @release_matters = @matters.where.not(status: 1)
+    @accepting_matters = @release_matters.where("deadline > ?", @deadline)
     @musician_user_id = Musician.find_by(user_id: current_user)
   end
 
@@ -36,11 +38,11 @@ class MattersController < ApplicationController
 
 
   def search
-    @matter_searchs = Matter.search(params[:search_word])
+    @matter_searchs = Matter.search(params[:search_word]).order("created_at DESC")
   end
 
   def category_search
-    @matter_category_searchs = Matter.where(matter_category_id: params[:matter_category_id])
+    @matter_category_searchs = Matter.where(matter_category_id: params[:matter_category_id]).order("created_at DESC")
   end
 
   private

--- a/app/controllers/musicians_controller.rb
+++ b/app/controllers/musicians_controller.rb
@@ -1,5 +1,6 @@
 class MusiciansController < ApplicationController
   before_action :set_musician, only: [:edit, :show, :update]
+  before_action :set_deadline, only: [:show]
 
   def index
 
@@ -40,6 +41,10 @@ class MusiciansController < ApplicationController
 
   def set_musician
     @musician = Musician.find(params[:id])
+  end
+
+  def set_deadline
+    @deadline = Time.zone.now - 1.days
   end
 
 end

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -6,6 +6,11 @@ class Matter < ApplicationRecord
   has_many :chats
   belongs_to :musician
   belongs_to :matter_category
+
+  enum status: {
+    公開:0,非公開:1
+  }, _prefix: true
+
   def self.search(search)
     if search
       Matter.joins(:musician).where(['title LIKE ? OR content LIKE ? OR name LIKE ?', "%#{search}%", "%#{search}%", "%#{search}%"])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
 
 
   enum status: {
-    公開:1,非公開:2
+    公開:0,非公開:1
   }, _prefix: true
 
   enum prefecture: {

--- a/app/views/applications_lists/index.html.haml
+++ b/app/views/applications_lists/index.html.haml
@@ -21,7 +21,7 @@
         = link_to "#{application.matter.musician.name}", "/musicians/#{application.matter.musician.id}", target: blank?
         %br
         応募締切日：
-        = application.matter.end
+        = application.matter.deadline
         %br
         %br
 

--- a/app/views/likes/index.html.haml
+++ b/app/views/likes/index.html.haml
@@ -22,7 +22,7 @@
         = link_to "#{like.matter.musician.name}", "/musicians/#{like.matter.musician.id}", target: blank?
         %br
         応募締切日：
-        = like.matter.end
+        = like.matter.deadline
         %br
         %br
 

--- a/app/views/matters/category_search.html.haml
+++ b/app/views/matters/category_search.html.haml
@@ -3,9 +3,6 @@
   - breadcrumb :category_search_matters
   = breadcrumbs separator: " &rsaquo; "
 %br
-= @matter_category_searchs.count
-件がヒットしました。
-%br
 
 %div
   ■キーワードで検索
@@ -21,27 +18,28 @@
 
 %ul.matters-list
   - @matter_category_searchs.each do |matter|
-    %li.matters-list__content
-      .matters-list__content__title
-        = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get
-      .matters-list__content__category
-        案件カテゴリ：
-        = matter.matter_category.name
-      .matters-list__content__reward
-        = matter.reward
-        円
-      .matters-list__content__deadline
-        応募締切日：
-        = matter.deadline
-      - if matter.start.present?
-        .matters-list__content__start
-          業務開始予定日：
-          = matter.start
-      .matters-list__content__end
-        業務終了予定日(希望納期)：
-        = matter.end
-      .matters-list__content__musician-name
-        案件依頼アーティスト：
-        = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
+    - if matter.deadline > @deadline
+      %li.matters-list__content
+        .matters-list__content__title
+          = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get
+        .matters-list__content__category
+          案件カテゴリ：
+          = matter.matter_category.name
+        .matters-list__content__reward
+          = matter.reward
+          円
+        .matters-list__content__deadline
+          応募締切日：
+          = matter.deadline
+        - if matter.start.present?
+          .matters-list__content__start
+            業務開始予定日：
+            = matter.start
+        .matters-list__content__end
+          業務終了予定日(希望納期)：
+          = matter.end
+        .matters-list__content__musician-name
+          案件依頼アーティスト：
+          = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
 
-    %br
+      %br

--- a/app/views/matters/edit.html.haml
+++ b/app/views/matters/edit.html.haml
@@ -93,6 +93,16 @@
   %br
 
 
+  .status
+    .status__title
+      ・公開設定
+    .status__norequired
+      必須
+  = f.select :status, Matter.statuses.keys, {promt: "---"}
+  %br
+  %br
+
+
   .actions
     = f.submit "案件依頼を更新する"
 

--- a/app/views/matters/index.html.haml
+++ b/app/views/matters/index.html.haml
@@ -42,32 +42,30 @@
 %br
 
 %ul.matters-list
-  - @matters.each do |matter|
-    - if matter.deadline > @deadline
-      %li.matters-list__content
-        .matters-list__content__title
-          = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get, target: blank?
-        .matters-list__content__category
-          案件カテゴリ：
-          = matter.matter_category.name
-        .matters-list__content__reward
-          お支払い金額：
-          = matter.reward
-          円
-        .matters-list__content__deadline
-          応募締切日：
-          = matter.deadline
-        - if matter.start.present?
-          .matters-list__content__start
-            業務開始予定日：
-            = matter.start
-        .matters-list__content__end
-          業務終了予定日(希望納期)：
-          = matter.end
-        .matters-list__content__musician-name
-          案件依頼アーティスト：
-          = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
-
+  - @accepting_matters.each do |matter|
+    %li.matters-list__content
+      .matters-list__content__title
+        = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get, target: blank?
+      .matters-list__content__category
+        案件カテゴリ：
+        = matter.matter_category.name
+      .matters-list__content__reward
+        お支払い金額：
+        = matter.reward
+        円
+      .matters-list__content__deadline
+        応募締切日：
+        = matter.deadline
+      - if matter.start.present?
+        .matters-list__content__start
+          業務開始予定日：
+          = matter.start
+      .matters-list__content__end
+        業務終了予定日(希望納期)：
+        = matter.end
+      .matters-list__content__musician-name
+        案件依頼アーティスト：
+        = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
     %br
 
   = paginate @matters

--- a/app/views/matters/new.html.haml
+++ b/app/views/matters/new.html.haml
@@ -97,5 +97,14 @@
   %br
 
 
+  .status
+    .status__title
+      ・公開設定
+    .status__norequired
+      必須
+  = f.select :status, Matter.statuses.keys, {promt: "---"}
+  %br
+  %br
+
   .actions
     = f.submit "案件依頼を作成する"

--- a/app/views/matters/search.html.haml
+++ b/app/views/matters/search.html.haml
@@ -3,9 +3,6 @@
   - breadcrumb :search_matters
   = breadcrumbs separator: " &rsaquo; "
 %br
-= @matter_searchs.count
-件がヒットしました。
-%br
 
 %div
   ■キーワードで検索
@@ -21,27 +18,28 @@
 
 %ul.matters-list
   - @matter_searchs.each do |matter|
-    %li.matters-list__content
-      .matters-list__content__title
-        = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get
-      .matters-list__content__category
-        案件カテゴリ：
-        = matter.matter_category.name
-      .matters-list__content__reward
-        = matter.reward
-        円
-      .matters-list__content__deadline
-        応募締切日：
-        = matter.deadline
-      - if matter.start.present?
-        .matters-list__content__start
-          業務開始予定日：
-          = matter.start
-      .matters-list__content__end
-        業務終了予定日(希望納期)：
-        = matter.end
-      .matters-list__content__musician-name
-        案件依頼アーティスト：
-        = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
+    - if matter.deadline > @deadline
+      %li.matters-list__content
+        .matters-list__content__title
+          = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get
+        .matters-list__content__category
+          案件カテゴリ：
+          = matter.matter_category.name
+        .matters-list__content__reward
+          = matter.reward
+          円
+        .matters-list__content__deadline
+          応募締切日：
+          = matter.deadline
+        - if matter.start.present?
+          .matters-list__content__start
+            業務開始予定日：
+            = matter.start
+        .matters-list__content__end
+          業務終了予定日(希望納期)：
+          = matter.end
+        .matters-list__content__musician-name
+          案件依頼アーティスト：
+          = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
 
-    %br
+      %br

--- a/app/views/matters/show.html.haml
+++ b/app/views/matters/show.html.haml
@@ -69,6 +69,13 @@
   = safe_join(@matter.supplement.split("\n"),tag(:br))
 - else
   指定はありません。
+%br
+
+- if user_signed_in? and @musician_user_id.present?
+  - if current_user.musician.id == @matter.musician_id
+    ■公開設定：
+    = @matter.status
+
 
 %br
 - if user_signed_in?

--- a/app/views/musicians/show.html.haml
+++ b/app/views/musicians/show.html.haml
@@ -116,13 +116,18 @@
 
 - if @matters.present?
   %br
-  ★アーティストの依頼案件一覧
+  ★このアーティストの依頼案件一覧
   %br
   %ul.matters-list
     - @matters.each do |matter|
       %li.matters-list__content
         .matters-list__content__title
           = link_to "案件名：#{matter.title}", "/matters/#{matter.id}", method: :get
+          - if user_signed_in?
+            - if current_user.id == @musician.user_id
+              (
+              = matter.status
+              )
           %br
           案件カテゴリ：
           = matter.matter_category.name
@@ -131,10 +136,12 @@
           = matter.reward
           円
           %br
-          依頼アーティスト：
-          = link_to "#{matter.musician.name}", "/musicians/#{matter.musician.id}", target: blank?
-          %br
           応募締切日：
-          = matter.end
+          = matter.deadline
+          %br
+          - if matter.deadline < @deadline
+            ※応募受付は終了しました。
           %br
           %br
+
+= link_to "TOPページへ戻る", root_path

--- a/app/views/offered_lists/index.html.haml
+++ b/app/views/offered_lists/index.html.haml
@@ -23,7 +23,7 @@
         = link_to "#{offer.matter.musician.name}", "/musicians/#{offer.matter.musician.id}", target: blank?
         %br
         応募締切日：
-        = offer.matter.end
+        = offer.matter.deadline
         %br
         .offers-list__content--confirm
           - if offer.status == 0

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -59,6 +59,3 @@
 
   .actions
     = f.submit "次へ"
-
-
--# = render "users/shared/links"


### PR DESCRIPTION
### 受付時間が過ぎた案件の表示を以下に修正。
・案件検索結果ページ：非表示にする。
・アーティストプロフィールページでの案件一覧：「この案件は受付が終了しました」の文言を表示する。

### 非公開になっている案件の表示を以下に修正。
・アーティストプロフィールページでの案件一覧、案件詳細ページ：ログインユーザーが案件依頼者の場合は「公開設定」を表示する。
・TOPページ、案件検索結果ページ：非表示にする。